### PR TITLE
Adds the ability to configure the IP address on which simple-brepl binds...

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,9 +24,9 @@ template does steps 1-3 for you):
      {:plugins [[jarohen/simple-brepl "0.1.0"]]}
    #+END_SRC
 
-   (Optional) You can include a =:brepl-port= key in your
-   =project.clj= to customise the port the bREPL listens to
-   (default 9001)
+   (Optional) You can include a =:brepl= key in your =project.clj=
+   with a map customising the IP and port the bREPL listens on
+   (default ={:ip "0.0.0.0" :port 9001}=)
    
 2. Include a snippet of JS in your web page to connect your browser to
    the REPL. The =(simple-brepl.service/brepl-js)= function provides the JS -

--- a/sample-project/project.clj
+++ b/sample-project/project.clj
@@ -15,8 +15,8 @@
                  
                  [org.clojure/clojurescript "0.0-2202"]]
 
-  :plugins [[jarohen/lein-frodo "0.3.0-SNAPSHOT"]
-            [jarohen/simple-brepl "0.1.0-SNAPSHOT"]
+  :plugins [[jarohen/lein-frodo "0.3.0"]
+            [jarohen/simple-brepl "0.1.0"]
             [lein-cljsbuild "1.0.3"]
             [lein-shell "0.4.0"]
 

--- a/simple-brepl-core/src/simple_brepl/client.cljs
+++ b/simple-brepl-core/src/simple_brepl/client.cljs
@@ -1,6 +1,7 @@
 (ns simple-brepl.client
   (:require [weasel.repl :as ws-repl]))
 
-(when-let [repl-port js/simple_brepl_port]
-  (ws-repl/connect (str "ws://" js/location.hostname ":" repl-port)))
+(when-let [repl-ip js/simple_brepl_ip]
+  (when-let [repl-port js/simple_brepl_port]
+    (ws-repl/connect (str "ws://" repl-ip ":" repl-port))))
 

--- a/simple-brepl-core/src/simple_brepl/service.clj
+++ b/simple-brepl-core/src/simple_brepl/service.clj
@@ -6,21 +6,26 @@
             [weasel.repl.websocket :as ws-repl]
             [weasel.repl.server :as ws-server]))
 
-(def ^:private !brepl-port
-  (atom nil))
+(def ^:private !brepl-config
+  (atom {}))
 
-(defn load-brepl! [brepl-port]
-  (reset! !brepl-port brepl-port)
+(defn load-brepl! [ip port]
+  (reset! !brepl-config {:ip ip :port port})
   (intern 'user 'simple-brepl
           (fn []
-            (p/cljs-repl :repl-env (ws-repl/repl-env :port brepl-port)))))
+            (p/cljs-repl :repl-env (ws-repl/repl-env :ip ip :port port)))))
  
 (defn brepl-open? []
   ;; Admittedly, this is quite a hack to decide whether the WS is
   ;; open...
   (boolean (:server @ws-server/state)))
 
+(defn- wrap-quotes [s]
+  (when s
+    (str \" s \")))
+
 (defn brepl-js []
-  (format "window.simple_brepl_port=%d;"
-          (when (brepl-open?)
-            @!brepl-port)))
+  (apply format "window.simple_brepl_ip=%s;window.simple_brepl_port=%d;"
+    (if (brepl-open?)
+      ((juxt (comp wrap-quotes :ip) :port) @!brepl-config)
+      [nil nil])))

--- a/simple-brepl/src/simple_brepl/plugin.clj
+++ b/simple-brepl/src/simple_brepl/plugin.clj
@@ -18,13 +18,13 @@
       with-piggieback-hook))
 
 (defn wrap-eval [eval-in-project project form & [init]]
-  (let [{:keys [brepl-port]
-         :or {brepl-port 9001}} project]
+  (let [{{:keys [ip port]
+          :or {ip "0.0.0.0" port 9001}} :brepl} project]
     
     (eval-in-project project
 
                      `(do
-                        (simple-brepl.service/load-brepl! ~brepl-port)
+                        (simple-brepl.service/load-brepl! ~ip ~port)
                         ~form)
        
                      `(do


### PR DESCRIPTION
....

Previously, the configuration was solely the port, optionally overridden via :brepl-port
key within project.clj. Now, the configuration is an optional :brepl key with a map
value that looks like {:ip "127.0.0.1" :port 3080}.
